### PR TITLE
Fix Makefile.am to support out-of-tree builds.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = cJSON rtaudio rtmidi mopo src po doc
 EXTRA_DIST = config.rpath patches
 
 patchesdir = $(pkgdatadir)/patches
-patches_DATA = patches/*.mite
+patches_DATA = $(top_srcdir)/patches/*.mite
 
 ACLOCAL_AMFLAGS = -I m4
 LDFLAGS += -L/usr/local/opt/gettext/lib


### PR DESCRIPTION
When building out of tree, all paths referenced in the Makefile.am should be
relative. The only change required to get this working is ensuring that the
"patches" directory is stated as relative to the directory the Makefile.am
is in. This commit fixes that.
