### PR TITLE
Print error when a library is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,8 @@ AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18.3])
 
 # Checks for libraries.
-AC_CHECK_LIB([intl], [gettext])
-AC_CHECK_LIB([ncurses], [curs_set])
-AC_CHECK_LIB([pthread], [pthread_create])
+AC_CHECK_LIB([ncurses], [curs_set],, AC_MSG_ERROR([cursynth requires the ncurses library!]))
+AC_CHECK_LIB([pthread], [pthread_create],, AC_MSG_ERROR([cursynth requires the pthread library!]))
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h float.h libintl.h limits.h locale.h math.h ncurses.h stddef.h stdlib.h string.h strings.h sys/ioctl.h sys/time.h unistd.h])
@@ -34,7 +33,6 @@ case $host in
     AC_MSG_RESULT(using OSS)
     api="$api -D__LINUX_OSS__"
     LIBS="$LIBS -lossaudio"
-    AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(cursynth requires the pthread library!))
   ;;
 
   *-*-linux*)
@@ -71,8 +69,6 @@ case $host in
     req="$req alsa"
     AC_CHECK_LIB(asound, snd_pcm_open, , AC_MSG_ERROR(ALSA support requires the asound library!))
   fi
-
-  AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(cursynth requires the pthread library!))
   ;;
 
   *-apple*)
@@ -97,8 +93,6 @@ case $host in
       [AC_MSG_ERROR(CoreAudio header files not found!)] )
     LIBS="$LIBS -framework CoreAudio -framework CoreMIDI -framework CoreFoundation"
   fi
-
-  AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(cursynth requires the pthread library!))
   ;;
 
   *-mingw32*)

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AM_PROG_AR
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18.3])
 AC_CHECK_PROG(MAKEINFO_CHECK,makeinfo,yes,no)
-if test x"$FFMPEG_CHECK" != x"yes" ; then
+if test x"$MAKEINFO_CHECK" != x"yes" ; then
     AC_MSG_ERROR([cursynth requires the makeinfo binary (for gettext)!])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,10 @@ AM_PROG_CC_C_O
 AM_PROG_AR
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18.3])
+AC_CHECK_PROG(MAKEINFO_CHECK,makeinfo,yes,no)
+if test x"$FFMPEG_CHECK" != x"yes" ; then
+    AC_MSG_ERROR([cursynth requires the makeinfo binary (for gettext)!])
+fi
 
 # Checks for libraries.
 AC_CHECK_LIB([ncurses], [curs_set],, AC_MSG_ERROR([cursynth requires the ncurses library!]))


### PR DESCRIPTION
Hi,

Just see that any errors was printed if a library was not found during ./configure. Corrected this.
Also remove multi-detection of the pthread library, and the detection of the intl library, because link to it is not necessary at all (On my system, it compile smoothly without, and fedora does not provide any intl library at all, only a preloadable_libintl.so (and his purpose is described here: https://www.gnu.org/software/gettext/manual/html_node/Prioritizing-messages.html)
