### PR TITLE
Add configure option to unbundle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,10 @@
-SUBDIRS = cJSON rtaudio rtmidi po doc
+SUBDIRS = cJSON rtmidi po doc
 EXTRA_DIST = config.rpath patches
+
+# For local rtaudio
+if RTAUDIO_LOCAL
+  SUBDIRS += rtaudio
+endif RTAUDIO_LOCAL
 
 # For local mopo
 if MOPO_LOCAL

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,10 @@
-SUBDIRS = cJSON po doc
+SUBDIRS = po doc
 EXTRA_DIST = config.rpath patches
+
+# For local rtaudio
+if CJSON_LOCAL
+  SUBDIRS += cJSON
+endif CJSON_LOCAL
 
 # For local rtaudio
 if RTAUDIO_LOCAL

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,12 @@
-SUBDIRS = cJSON rtaudio rtmidi mopo src po doc
+SUBDIRS = cJSON rtaudio rtmidi po doc
 EXTRA_DIST = config.rpath patches
+
+# For local mopo
+if MOPO_LOCAL
+  SUBDIRS += mopo
+endif MOPO_LOCAL
+
+SUBDIRS += src
 
 patchesdir = $(pkgdatadir)/patches
 patches_DATA = $(top_srcdir)/patches/*.mite

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,14 @@
-SUBDIRS = cJSON rtmidi po doc
+SUBDIRS = cJSON po doc
 EXTRA_DIST = config.rpath patches
 
 # For local rtaudio
 if RTAUDIO_LOCAL
   SUBDIRS += rtaudio
+endif RTAUDIO_LOCAL
+
+# For local rtmidi
+if RTAUDIO_LOCAL
+  SUBDIRS += rtmidi
 endif RTAUDIO_LOCAL
 
 # For local mopo

--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,8 @@ AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18.3])
 
 # Checks for libraries.
-AC_CHECK_LIB([intl], [gettext])
-AC_CHECK_LIB([ncurses], [curs_set])
-AC_CHECK_LIB([pthread], [pthread_create])
+AC_CHECK_LIB([ncurses], [curs_set],, AC_MSG_ERROR([cursynth requires the ncurses library!]))
+AC_CHECK_LIB([pthread], [pthread_create],, AC_MSG_ERROR([cursynth requires the pthread library!]))
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h float.h libintl.h limits.h locale.h math.h ncurses.h stddef.h stdlib.h string.h strings.h sys/ioctl.h sys/time.h unistd.h])
@@ -34,7 +33,6 @@ case $host in
     AC_MSG_RESULT(using OSS)
     api="$api -D__LINUX_OSS__"
     LIBS="$LIBS -lossaudio"
-    AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(cursynth requires the pthread library!))
   ;;
 
   *-*-linux*)
@@ -71,8 +69,6 @@ case $host in
     req="$req alsa"
     AC_CHECK_LIB(asound, snd_pcm_open, , AC_MSG_ERROR(ALSA support requires the asound library!))
   fi
-
-  AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(cursynth requires the pthread library!))
   ;;
 
   *-apple*)
@@ -97,8 +93,6 @@ case $host in
       [AC_MSG_ERROR(CoreAudio header files not found!)] )
     LIBS="$LIBS -framework CoreAudio -framework CoreMIDI -framework CoreFoundation"
   fi
-
-  AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR(cursynth requires the pthread library!))
   ;;
 
   *-mingw32*)

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,17 @@ case $host in
 esac
 
   # Use bundled libraries or not ?
+  # CJSON
+  AC_ARG_WITH(external-cJSON, [ --with-external-cJSON = Build using external cjson library], [
+    AC_CHECK_LIB(cJSON, main, , AC_MSG_ERROR(Using external rtaudio requires libcJSON installed!))
+    external_cJSON=true
+    AC_MSG_RESULT(using external cJSON)], [
+    AC_CONFIG_FILES(cJSON/Makefile)
+    external_cJSON=false
+    AC_MSG_RESULT(using internal cJSON)
+  ])
+  AM_CONDITIONAL([CJSON_LOCAL], [test x$external_cJSON = xfalse])
+
   # Mopo
   AC_ARG_WITH(external-mopo, [ --with-external-mopo = Build using external mopo library], [
     AC_CHECK_LIB(mopo, main, , AC_MSG_ERROR(Using external mopo requires libmopo installed!))
@@ -153,10 +164,10 @@ esac
   # RtMidi
   AC_ARG_WITH(external-rtmidi, [ --with-external-rtmidi = Build using external rtmidi library], [
     AC_CHECK_LIB(rtmidi, main, , AC_MSG_ERROR(Using external rtaudio requires librtmidi installed!))
-    external_rtaudio=true
+    external_rtmidi=true
     AC_MSG_RESULT(using external rtmidi)], [
     AC_CONFIG_SUBDIRS(rtmidi)
-    external_rtaudio=false
+    external_rtmidi=false
     AC_MSG_RESULT(using internal rtmidi)
   ])
   AM_CONDITIONAL([RTMIDI_LOCAL], [test x$external_rtmidi = xfalse])
@@ -180,6 +191,5 @@ AC_CHECK_FUNCS([dup2 floor gettimeofday memset modf pow rmdir strcasecmp strchr 
 
 AC_CONFIG_FILES([Makefile po/Makefile.in
                  src/Makefile
-                 cJSON/Makefile
                  doc/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,17 @@ esac
   ])
   AM_CONDITIONAL([MOPO_LOCAL], [test x$external_mopo = xfalse])
 
+  # RtAudio
+  AC_ARG_WITH(external-rtaudio, [ --with-external-rtaudio = Build using external rtaudio library], [
+    AC_CHECK_LIB(rtaudio, main, , AC_MSG_ERROR(Using external rtaudio requires librtaudio installed!))
+    external_rtaudio=true
+    AC_MSG_RESULT(using external rtaudio)], [
+    AC_CONFIG_SUBDIRS(rtaudio)
+    external_rtaudio=false
+    AC_MSG_RESULT(using internal rtaudio)
+  ])
+  AM_CONDITIONAL([RTAUDIO_LOCAL], [test x$external_rtaudio = xfalse])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_PID_T
@@ -156,8 +167,7 @@ AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([dup2 floor gettimeofday memset modf pow rmdir strcasecmp strchr strdup strerror])
 
-AC_CONFIG_SUBDIRS([rtaudio
-                   rtmidi])
+AC_CONFIG_SUBDIRS([rtmidi])
 
 AC_CONFIG_FILES([Makefile po/Makefile.in
                  src/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AM_PROG_AR
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18.3])
 AC_CHECK_PROG(MAKEINFO_CHECK,makeinfo,yes,no)
-if test x"$FFMPEG_CHECK" != x"yes" ; then
+if test x"$MAKEINFO_CHECK" != x"yes" ; then
     AC_MSG_ERROR([cursynth requires the makeinfo binary (for gettext)!])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,17 @@ esac
   ])
   AM_CONDITIONAL([RTAUDIO_LOCAL], [test x$external_rtaudio = xfalse])
 
+  # RtMidi
+  AC_ARG_WITH(external-rtmidi, [ --with-external-rtmidi = Build using external rtmidi library], [
+    AC_CHECK_LIB(rtmidi, main, , AC_MSG_ERROR(Using external rtaudio requires librtmidi installed!))
+    external_rtaudio=true
+    AC_MSG_RESULT(using external rtmidi)], [
+    AC_CONFIG_SUBDIRS(rtmidi)
+    external_rtaudio=false
+    AC_MSG_RESULT(using internal rtmidi)
+  ])
+  AM_CONDITIONAL([RTMIDI_LOCAL], [test x$external_rtmidi = xfalse])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_PID_T
@@ -166,8 +177,6 @@ AC_FUNC_ERROR_AT_LINE
 AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([dup2 floor gettimeofday memset modf pow rmdir strcasecmp strchr strdup strerror])
-
-AC_CONFIG_SUBDIRS([rtmidi])
 
 AC_CONFIG_FILES([Makefile po/Makefile.in
                  src/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,18 @@ case $host in
   ;;
 esac
 
+  # Use bundled libraries or not ?
+  # Mopo
+  AC_ARG_WITH(external-mopo, [ --with-external-mopo = Build using external mopo library], [
+    AC_CHECK_LIB(mopo, main, , AC_MSG_ERROR(Using external mopo requires libmopo installed!))
+    external_mopo=true
+    AC_MSG_RESULT(using external mopo)], [
+    AC_CONFIG_SUBDIRS(mopo/)
+    external_mopo=false
+    AC_MSG_RESULT(using internal mopo)
+  ])
+  AM_CONDITIONAL([MOPO_LOCAL], [test x$external_mopo = xfalse])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_PID_T
@@ -144,8 +156,7 @@ AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([dup2 floor gettimeofday memset modf pow rmdir strcasecmp strchr strdup strerror])
 
-AC_CONFIG_SUBDIRS([mopo
-                   rtaudio
+AC_CONFIG_SUBDIRS([rtaudio
                    rtmidi])
 
 AC_CONFIG_FILES([Makefile po/Makefile.in

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,10 @@ AM_PROG_CC_C_O
 AM_PROG_AR
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18.3])
+AC_CHECK_PROG(MAKEINFO_CHECK,makeinfo,yes,no)
+if test x"$FFMPEG_CHECK" != x"yes" ; then
+    AC_MSG_ERROR([cursynth requires the makeinfo binary (for gettext)!])
+fi
 
 # Checks for libraries.
 AC_CHECK_LIB([ncurses], [curs_set],, AC_MSG_ERROR([cursynth requires the ncurses library!]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,8 +16,6 @@ cursynth_CPPFLAGS = -I. \
                     -I.. \
                     -I$(top_srcdir)/cJSON \
                     -I$(top_srcdir)/rtmidi \
-                    -I$(top_srcdir)/mopo/src \
-                    -I$(top_srcdir)/mopo/src \
 		    -I/usr/local/opt/gettext/include \
                     -DPATCHES_DIRECTORY=\"$(patchesdir)\"
 
@@ -32,5 +30,6 @@ endif RTAUDIO_LOCAL
 
 # For local mopo
 if MOPO_LOCAL
+  cursynth_CPPFLAGS += -I$(top_srcdir)/mopo/src
   cursynth_LDADD += ../mopo/src/libmopo.a
 endif MOPO_LOCAL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,5 +24,9 @@ cursynth_CPPFLAGS = -I. \
 
 cursynth_LDADD = ../cJSON/libcJSON.a \
                  ../rtaudio/librtaudio.a \
-                 ../rtmidi/librtmidi.a \
-                 ../mopo/src/libmopo.a
+                 ../rtmidi/librtmidi.a 
+
+# For local mopo
+if MOPO_LOCAL
+  cursynth_LDADD += ../mopo/src/libmopo.a
+endif MOPO_LOCAL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,16 +15,20 @@ cursynth_SOURCES = main.cpp \
 cursynth_CPPFLAGS = -I. \
                     -I.. \
                     -I$(top_srcdir)/cJSON \
-                    -I$(top_srcdir)/rtaudio \
                     -I$(top_srcdir)/rtmidi \
                     -I$(top_srcdir)/mopo/src \
                     -I$(top_srcdir)/mopo/src \
-										-I/usr/local/opt/gettext/include \
+		    -I/usr/local/opt/gettext/include \
                     -DPATCHES_DIRECTORY=\"$(patchesdir)\"
 
 cursynth_LDADD = ../cJSON/libcJSON.a \
-                 ../rtaudio/librtaudio.a \
                  ../rtmidi/librtmidi.a 
+
+# For local rtaudio
+if RTAUDIO_LOCAL
+  cursynth_CPPFLAGS += -I$(top_srcdir)/rtaudio
+  cursynth_LDADD += ../rtaudio/librtaudio.a
+endif RTAUDIO_LOCAL
 
 # For local mopo
 if MOPO_LOCAL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,25 +18,41 @@ cursynth_CPPFLAGS = -I. \
                     -DPATCHES_DIRECTORY=\"$(patchesdir)\"
 
 # For local cJSON
-if MOPO_LOCAL
+if CJSON_LOCAL
   cursynth_CPPFLAGS += -I$(top_srcdir)/cJSON 
-  cursynth_LDADD += ../cJSON/libcJSON.a
-endif MOPO_LOCAL
+  if !cursynth_LDADD
+    cursynth_LDADD = ../cJSON/libcJSON.a
+  else
+    cursynth_LDADD += ../cJSON/libcJSON.a
+  endif
+endif CJSON_LOCAL
 
 # For local mopo
 if MOPO_LOCAL
   cursynth_CPPFLAGS += -I$(top_srcdir)/mopo/src
-  cursynth_LDADD += ../mopo/src/libmopo.a
+  if !cursynth_LDADD
+    cursynth_LDADD = ../mopo/src/libmopo.a
+  else
+    cursynth_LDADD += ../mopo/src/libmopo.a
+  endif
 endif MOPO_LOCAL
 
 # For local rtaudio
 if RTAUDIO_LOCAL
   cursynth_CPPFLAGS += -I$(top_srcdir)/rtaudio
-  cursynth_LDADD += ../rtaudio/librtaudio.a
+  if !cursynth_LDADD
+    cursynth_LDADD = ../rtaudio/librtaudio.a
+  else
+    cursynth_LDADD += ../rtaudio/librtaudio.a
+  endif 
 endif RTAUDIO_LOCAL
 
 # For local rtmidi
-if RTAUDIO_LOCAL
+if RTMIDI_LOCAL
   cursynth_CPPFLAGS += -I$(top_srcdir)/rtmidi
-  cursynth_LDADD += ../rtmidi/librtmidi.a 
-endif RTAUDIO_LOCAL
+  if !cursynth_LDADD
+    cursynth_LDADD = ../rtmidi/librtmidi.a 
+  else 
+    cursynth_LDADD += ../rtmidi/librtmidi.a 
+  endif
+endif RTMIDI_LOCAL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,13 +14,20 @@ cursynth_SOURCES = main.cpp \
 
 cursynth_CPPFLAGS = -I. \
                     -I.. \
-                    -I$(top_srcdir)/cJSON \
-                    -I$(top_srcdir)/rtmidi \
 		    -I/usr/local/opt/gettext/include \
                     -DPATCHES_DIRECTORY=\"$(patchesdir)\"
 
-cursynth_LDADD = ../cJSON/libcJSON.a \
-                 ../rtmidi/librtmidi.a 
+# For local cJSON
+if MOPO_LOCAL
+  cursynth_CPPFLAGS += -I$(top_srcdir)/cJSON 
+  cursynth_LDADD += ../cJSON/libcJSON.a
+endif MOPO_LOCAL
+
+# For local mopo
+if MOPO_LOCAL
+  cursynth_CPPFLAGS += -I$(top_srcdir)/mopo/src
+  cursynth_LDADD += ../mopo/src/libmopo.a
+endif MOPO_LOCAL
 
 # For local rtaudio
 if RTAUDIO_LOCAL
@@ -28,8 +35,8 @@ if RTAUDIO_LOCAL
   cursynth_LDADD += ../rtaudio/librtaudio.a
 endif RTAUDIO_LOCAL
 
-# For local mopo
-if MOPO_LOCAL
-  cursynth_CPPFLAGS += -I$(top_srcdir)/mopo/src
-  cursynth_LDADD += ../mopo/src/libmopo.a
-endif MOPO_LOCAL
+# For local rtmidi
+if RTAUDIO_LOCAL
+  cursynth_CPPFLAGS += -I$(top_srcdir)/rtmidi
+  cursynth_LDADD += ../rtmidi/librtmidi.a 
+endif RTAUDIO_LOCAL

--- a/src/cursynth.cpp
+++ b/src/cursynth.cpp
@@ -16,7 +16,13 @@
 
 #include "cursynth.h"
 
-#include "cJSON.h"
+#include "config.h"
+
+#ifdef HAVE_LIBCJSON
+#include <cjson/cJSON.h>
+#else
+#include "cjson.h"
+#endif
 
 #include <cstdio>
 #include <cstdlib>

--- a/src/cursynth.h
+++ b/src/cursynth.h
@@ -18,7 +18,7 @@
 #ifndef CURSYNTH_H
 #define CURSYNTH_H
 
-#ifdef HAVE_LIBrtaudio
+#ifdef HAVE_LIBRTAUDIO
 #include <RtAudio.h>
 #else
 #include "RtAudio.h"

--- a/src/cursynth.h
+++ b/src/cursynth.h
@@ -24,7 +24,12 @@
 #include "RtAudio.h"
 #endif
 
+#ifdef HAVE_LIBRTMIDI
+#include <RtMidi.h>
+#else
 #include "RtMidi.h"
+#endif
+
 #include "cursynth_gui.h"
 #include "cursynth_engine.h"
 

--- a/src/cursynth.h
+++ b/src/cursynth.h
@@ -18,7 +18,12 @@
 #ifndef CURSYNTH_H
 #define CURSYNTH_H
 
+#ifdef HAVE_LIBrtaudio
+#include <RtAudio.h>
+#else
 #include "RtAudio.h"
+#endif
+
 #include "RtMidi.h"
 #include "cursynth_gui.h"
 #include "cursynth_engine.h"

--- a/src/cursynth_common.h
+++ b/src/cursynth_common.h
@@ -19,7 +19,12 @@
 #define CURSYNTH_COMMON_H
 
 #include "config.h"
+
+#ifdef HAVE_LIBMOPO
+#include <mopo/value.h>
+#else
 #include "value.h"
+#endif
 
 #include <map>
 #include <string>

--- a/src/cursynth_engine.cpp
+++ b/src/cursynth_engine.cpp
@@ -16,6 +16,20 @@
 
 #include "cursynth_engine.h"
 
+#include "config.h"
+
+#ifdef HAVE_LIBMOPO
+#include <mopo/delay.h>
+#include <mopo/envelope.h>
+#include <mopo/filter.h>
+#include <mopo/operators.h>
+#include <mopo/oscillator.h>
+#include <mopo/processor_router.h>
+#include <mopo/linear_slope.h>
+#include <mopo/smooth_value.h>
+#include <mopo/trigger_operators.h>
+#include <mopo/value.h>
+#else
 #include "delay.h"
 #include "envelope.h"
 #include "filter.h"
@@ -24,9 +38,11 @@
 #include "processor_router.h"
 #include "linear_slope.h"
 #include "smooth_value.h"
-#include "cursynth_strings.h"
 #include "trigger_operators.h"
 #include "value.h"
+#endif
+
+#include "cursynth_strings.h"
 
 #include <sstream>
 

--- a/src/cursynth_engine.h
+++ b/src/cursynth_engine.h
@@ -18,12 +18,23 @@
 #ifndef CURSYNTH_SYNTH_H
 #define CURSYNTH_SYNTH_H
 
+#include "config.h"
+
+#ifdef HAVE_LIBMOPO
+#include <mopo/feedback.h>
+#include <mopo/operators.h>
+#include <mopo/oscillator.h>
+#include <mopo/tick_router.h>
+#include <mopo/voice_handler.h>
+#else
 #include "feedback.h"
 #include "operators.h"
 #include "oscillator.h"
-#include "cursynth_common.h"
 #include "tick_router.h"
 #include "voice_handler.h"
+#endif
+
+#include "cursynth_common.h"
 
 #include <vector>
 

--- a/src/cursynth_gui.cpp
+++ b/src/cursynth_gui.cpp
@@ -16,7 +16,11 @@
 
 #include "cursynth_gui.h"
 
+#ifdef HAVE_LIBMOPO
+#include <mopo/value.h>
+#else
 #include "value.h"
+#endif
 
 #include <cmath>
 #include <cstdlib>

--- a/src/cursynth_gui.h
+++ b/src/cursynth_gui.h
@@ -18,7 +18,15 @@
 #ifndef CURSYNTH_GUI_H
 #define CURSYNTH_GUI_H
 
+// Include here first
+#include "config.h"
+
+#ifdef HAVE_LIBMOPO
+#include <mopo/mopo.h>
+#else
 #include "mopo.h"
+#endif
+
 #include "cursynth_common.h"
 
 #include <map>


### PR DESCRIPTION
Hi,

Here, I add four new argument in the configure file:
--with-external-cjson
--with-external-mopo
--with-external-rtaudio
--with-external-rtmidi

Each one can be use separately, and use system libraries instead of bundled ones. I will now work on a rpm for an integration in Fedora.
